### PR TITLE
Allow Previously Allowed Endpoints and Update `var` to `let`

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ window.addEventListener("load", () => {
          * Paths should be objects with a domain and path
          */
     ];
+    
+    const previouslyAllowed = []; // Starts as empty since nothing has been allowed
 
     function comparePaths(_a, _b) {
         let a = _a.split("#")[0].split("?")[0];
@@ -54,9 +56,9 @@ window.addEventListener("load", () => {
             return callback(a, b, c, this);
         };
 
-        XMLHttpRequest.prototype.open = function (a, b) {
-            if (!a) var a = '';
-            if (!b) var b = '';
+        XMLHttpRequest.prototype.open = function (_a, _b) {
+            let a = _a || '';
+            let b = _b || '';
             xmlHttpRequestListener.tempOpen.apply(this, arguments);
             xmlHttpRequestListener.method = a;
             xmlHttpRequestListener.url = b;
@@ -66,13 +68,12 @@ window.addEventListener("load", () => {
             }
         }
 
-        XMLHttpRequest.prototype.send = function (a, b) {
-            let result =
-                xmlHttpRequestListener.callback(a, b, false);
+        XMLHttpRequest.prototype.send = function (_a, _b) {
+            let a = _a || '';
+            let b = _b || '';
+            let result = xmlHttpRequestListener.callback(a, b, false);
             if (result == "DROP_REQUEST") return;
-            console.log(result);
-            if (!a) var a = '';
-            if (!b) var b = '';
+            
             xmlHttpRequestListener.tempSend.apply(this, arguments);
             if (xmlHttpRequestListener.method.toLowerCase() == 'post') xmlHttpRequestListener.data = a;
         }
@@ -114,7 +115,7 @@ window.addEventListener("load", () => {
         const domain = urlReader.hostname;
         const path = urlReader.pathname;
 
-        let allowed = parseURL();
+        let allowed = parseURL().concat(previouslyAllowed);
         for (let i of allowed) {
             if (i.domain == domain && comparePaths(i.path, path)) {
                 if (!("method" in i) || i.method == method)
@@ -122,8 +123,12 @@ window.addEventListener("load", () => {
             }
         }
 
+        
+        const confirmed = confirm(`Request to ${requestURL} of method ${method}`);
+        
+        if(confirmed) previouslyAllowed.push({domain, path, method});
 
-        return confirm(`Request to ${requestURL}`) ? "" : "DROP_REQUEST";
+        return confirmed ? "" : "DROP_REQUEST";
     }
 
     overrideRequests(confirmPath);


### PR DESCRIPTION
`var` was originally used so I could redefine the parameter outside of the block scope of the if statement, but `let` with short-circuiting is better, although it means I had to rename the parameters I used. (not wanting to do that is why I originally used `var`, but `var` is less secure and may be vulnerable to memory leaks)

This PR also allows previously allowed endpoints so that you don't have to click to allow each individual one.